### PR TITLE
feat: scatter-plot expense data

### DIFF
--- a/server/controllers/expense/index.ts
+++ b/server/controllers/expense/index.ts
@@ -174,6 +174,23 @@ export class ExpenseController {
     });
   }
 
+  static async scatteredPlotExpData(req: any, res: Response): Promise<any> {
+    const {
+      auth: { _id },
+      query: { period },
+    } = req;
+
+    const plotData = await ExpenseController.expenseDataAgent.scatteredPlotExpData(
+      _id,
+      period,
+    );
+
+    return res.status(200).json({
+      success: true,
+      plotData,
+    });
+  }
+
   // helper methods
   static async getById(
     req: any,

--- a/server/database/data-agents/expense/ExpenseDataAgent.ts
+++ b/server/database/data-agents/expense/ExpenseDataAgent.ts
@@ -220,4 +220,28 @@ export class ExpenseDataAgent extends DataAgent<IExpenseDocument> {
 
     return categoryExpAggregates;
   }
+
+  async scatteredPlotExpData(userId: string, period: Date): Promise<any> {
+    const date = new Date(period);
+
+    const y = date.getFullYear();
+
+    const m = date.getMonth();
+
+    const firstDay = new Date(y, m, 1);
+
+    const lastDay = new Date(y, m + 1, 0);
+
+    const plotData = ExpenseModel.aggregate([
+      {
+        $match: {
+          incurredOn: { $gte: firstDay, $lt: lastDay },
+          recordedBy: Types.ObjectId(userId),
+        },
+      },
+      { $project: { x: { daysOfMonth: '$incurredOn' }, y: '$amount' } },
+    ]);
+
+    return plotData;
+  }
 }

--- a/server/routers/ExpenseRouter.ts
+++ b/server/routers/ExpenseRouter.ts
@@ -21,6 +21,10 @@ expenseRouter
   .get(authenticate, ExpenseController.expensesByCategory);
 
 expenseRouter
+  .route('/api/v1/expenses/plot')
+  .get(authenticate, ExpenseController.scatteredPlotExpData);
+
+expenseRouter
   .route('/api/v1/expenses/:expId')
   .get(authenticate, authorize, ExpenseController.read)
   .patch(authenticate, authorize, ExpenseController.update)

--- a/test/expense/scatteredPlotExpData.spec.ts
+++ b/test/expense/scatteredPlotExpData.spec.ts
@@ -5,16 +5,22 @@ import { validExpenseObject, aggExpenses, createExpense } from './fixtures';
 import { expect } from '..';
 
 const baseUrl = '/api/v1';
-describe('aggregated expenses by category', () => {
+describe('scattered plot expense data', () => {
   const app = new Application();
   let result: any;
+  let expense: any;
 
   before(async () => {
     result = await createUser(app, baseUrl, UserModelFixture.validUserObject);
   });
 
   before(async () => {
-    await createExpense(app, baseUrl, result.body.token, validExpenseObject);
+    expense = await createExpense(
+      app,
+      baseUrl,
+      result.body.token,
+      validExpenseObject,
+    );
   });
 
   after(async () => {
@@ -25,11 +31,11 @@ describe('aggregated expenses by category', () => {
     );
   });
 
-  describe('when a request is made to view expenses aggregated by category for the current month', () => {
+  describe('when a request is made to view sccattered expenses data aggregated by month and amount for the specified period', () => {
     it('an aggregated expenses response should be returned', async () => {
       const res = await aggExpenses(
         app,
-        `${baseUrl}/expenses/by/category`,
+        `${baseUrl}/expenses/plot/?${expense.body.expense.incurredOn}`,
         result.body.token,
       );
 


### PR DESCRIPTION
#### Decribe what this PR does

- adds scatter-plot expense data functionality

#### Describe the tasks that support this PR

- add scatter-plot-exp-data agent and controller handlers
- add /expenses/plot route
- add e2e tests

#### Outline the changes made to the existing functionality if any

#### Select the test categories recorded for this feature / fix

- [ ] unit tests

- [x] e2e tests

- [ ] integration tests

#### Outline the steps required to manually test your implementation

`Development Environment setup`

- clone the repository and run `cd traxpence-api` to change to the project directory
- run `yarn` command to install all the necessary dependencies and build the application
- run `yarn start` or `yarn run dev` command to run the application

`Test Environment setup`

- run `yarn test` command to run all tests