### PR TITLE
fix: refactor expenses pagination cursor param to ref incurredOn field

### DIFF
--- a/server/controllers/expense/index.ts
+++ b/server/controllers/expense/index.ts
@@ -73,7 +73,7 @@ export class ExpenseController {
       success: true,
       count: expenses.length,
       expenses,
-      cursor: hasNextPage ? expenses[expenses.length - 1]._id : 'done',
+      cursor: hasNextPage ? expenses[expenses.length - 1].incurredOn : 'done',
       hasNextPage,
     });
   }

--- a/server/database/data-agents/expense/ExpenseDataAgent.ts
+++ b/server/database/data-agents/expense/ExpenseDataAgent.ts
@@ -27,7 +27,7 @@ export class ExpenseDataAgent extends BaseDataAgent<IExpenseDocument> {
     userId: string,
     startDate?: Date,
     endDate?: Date,
-    cursor?: string,
+    cursor?: Date,
   ): Promise<IExpenseDocument[]> {
     const firstDay = startDate && new Date(startDate);
     const lastDay = endDate && new Date(endDate);
@@ -42,7 +42,7 @@ export class ExpenseDataAgent extends BaseDataAgent<IExpenseDocument> {
 
     if (cursor) {
       query = {
-        $and: [{ recordedBy: userId }, { _id: { $lt: cursor } }],
+        $and: [{ recordedBy: userId }, { incurredOn: { $lt: cursor } }],
       };
     }
 
@@ -51,7 +51,7 @@ export class ExpenseDataAgent extends BaseDataAgent<IExpenseDocument> {
         $and: [
           { recordedBy: userId },
           { incurredOn: { $gte: firstDay, $lte: lastDay } },
-          { _id: { $lt: cursor } },
+          { incurredOn: { $lt: cursor } },
         ],
       };
     }


### PR DESCRIPTION
#### Decribe what this PR does

- refactors expenses pagination cursor param to reference incurredOn expense field instead of _id

#### Outline the steps required to manually test your implementation

`Development Environment setup`

- clone the repository and run `cd traxpence-api` to change to the project directory
- run `yarn` command to install all the necessary dependencies and build the application
- run `yarn start` or `yarn run dev` command to run the application

`Test Environment setup`

- run `yarn test` command to run all tests